### PR TITLE
Enable i386 build again.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["i386", "x86_64"]
+  "skip-arches": ["aarch64", "arm"]
 }


### PR DESCRIPTION
Using only-arches seems to limit to 64bit build only, even when i386 is included in the list.