### PR TITLE
Bump lib3mf, Clipper2 and OpenSCAD.

### DIFF
--- a/org.openscad.OpenSCAD.yaml
+++ b/org.openscad.OpenSCAD.yaml
@@ -203,13 +203,13 @@ modules:
       - -DSUFFIX=nightly
       - -DSNAPSHOT=ON
       - -DUSE_QT6=ON
-      - -DOPENSCAD_VERSION=2026.01.24.fp
-      - -DOPENSCAD_COMMIT=e7e0f47fa
+      - -DOPENSCAD_VERSION=2026.02.25.fp
+      - -DOPENSCAD_COMMIT=ae3a780
     cleanup:
       - /share/pixmaps
     sources:
       - type: git
         url: https://github.com/openscad/openscad.git
-        commit: e7e0f47fac86f2a3c69f5e7767680ce5a34a6d32
+        commit: ae3a780de777bcb96d41631818551650bc79650d
     post-install:
       - sed -i -e 's/\(<id>org.openscad.OpenSCAD\)-nightly/\1/' /app/share/metainfo/org.openscad.OpenSCAD-nightly.appdata.xml

--- a/org.openscad.OpenSCAD.yaml
+++ b/org.openscad.OpenSCAD.yaml
@@ -50,8 +50,8 @@ modules:
       - -DCLIPPER2_TESTS=OFF
     sources:
       - type: archive
-        url: https://github.com/AngusJohnson/Clipper2/archive/refs/tags/Clipper2_1.5.4.tar.gz
-        sha256: 9d8a35a29d04cd1b7b45f542c0ba48015feece1210036ea9e4efaad3140af4b0
+        url: https://github.com/AngusJohnson/Clipper2/archive/refs/tags/Clipper2_2.0.1.tar.gz
+        sha256: 2a3693aceab4aed3e39b743e038d87701acc53cf05ed7b2013aab3e0aec5287e
   - name: boost
     buildsystem: simple
     build-commands:

--- a/org.openscad.OpenSCAD.yaml
+++ b/org.openscad.OpenSCAD.yaml
@@ -156,8 +156,9 @@ modules:
       - -DUSE_INCLUDED_LIBZIP=OFF
     sources:
       - type: archive
-        url: https://github.com/3MFConsortium/lib3mf/archive/refs/tags/v2.5.0-alpha.tar.gz
-        sha256: 78b9462ef52d2e1167a60d93f6583173669f8061d534b74c43477f6bd71cd35e
+        strip-components: 0
+        url: https://github.com/3MFConsortium/lib3mf/releases/download/v2.5.0/lib3mf-2.5.0-source-with-submodules.zip
+        sha256: 6510552a576fe95f02230f7d1c48ac18f2516fd82ae8cd082695241310963124
   - name: libspnav
     sources:
       - type: archive


### PR DESCRIPTION
* Bump lib3mf to 2.5.0.
* Bump Clipper2 to 2.0.1.
* Bump OpenSCAD to https://github.com/openscad/openscad/commit/ae3a780de777bcb96d41631818551650bc79650d